### PR TITLE
fractions.gcd() has been deprecated since Python 3.5,

### DIFF
--- a/mynblep/minblep.py
+++ b/mynblep/minblep.py
@@ -17,7 +17,11 @@
 
 from .paste import pasteminbleps
 from .shapes import floatdtype
-from fractions import gcd
+try:
+    from fractions import gcd
+except ImportError:
+    # python >= 3.9
+    from math import gcd
 from lagoon.util import atomic
 from pathlib import Path
 import logging, numpy as np, pickle


### PR DESCRIPTION
and removed from Python 3.9 (see https://bugs.python.org/issue39350)
So when gcd cannot be imported from fractions,
try to import it from math.

Fixes issue https://github.com/combatopera/pym2149/issues/81.